### PR TITLE
fix sortable with empty options

### DIFF
--- a/Sortable.php
+++ b/Sortable.php
@@ -111,7 +111,7 @@ class Sortable extends \yii\base\Widget
 
         $js .= "Sortable.create({$id},";
         
-        $clientOptions = Json::encode($this->clientOptions);
+        $clientOptions = Json::encode($this->clientOptions, JSON_FORCE_OBJECT);
 
         $js .= $clientOptions;
 


### PR DESCRIPTION
Если вызвать виджет, без передачи настроек, будет ошибка, так как options должен быть объект.
Добавил JSON_FORCE_OBJECT.
